### PR TITLE
Removes `have_tti_time_stats` option from ue.conf

### DIFF
--- a/snap/local/ue.conf
+++ b/snap/local/ue.conf
@@ -459,7 +459,6 @@ enable = false
 metrics_csv_enable    = false
 metrics_period_secs   = 1
 metrics_csv_filename  = /var/snap/srsran/current/ue_metrics.csv
-have_tti_time_stats   = true
 tracing_enable        = true
 tracing_filename      = /var/snap/srsran/current/ue_tracing.log
 tracing_buffcapacity  = 1000000


### PR DESCRIPTION
Removes `have_tti_time_stats` option from ue.conf because the current config file causes this error to happen:

```
ubuntu@ip-172-31-5-216:~$ sudo /snap/bin/srsran.srsue --usim.algo=milenage --usim.imsi=001010000000001 --usim.k=00112233445566778899aabbccddeeff --usim.opc=63BFA50EE6523365FF14C1F45F88737D --rf.device_name=zmq --rf.device_args=tx_port=tcp://*:2001,rx_port=tcp://localhost:2000,id=ue,base_srate=23.04e6 ue.conf
Active RF plugins: libsrsran_rf_zmq.so
Inactive RF plugins: 
Reading configuration file ue.conf...
unrecognised option 'general.have_tti_time_stats'
```