### PR TITLE
Remove unneeded system-files plug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,13 +20,9 @@ confinement: strict
 icon: snap/local/srsran.png
 website: https://www.srsran.com/
 source-code: https://github.com/canonical/srsran-snap
-license: Apache-2.0
+license: AGPL-3.0
 
 plugs:
-  etc-hosts:
-    interface: system-files
-    read:
-      - /etc/hosts
   network:
   network-bind:
   network-control:


### PR DESCRIPTION
`system-files` plug was not required because `network-control` already gives that access.

Also follow the license of upstream.