### PR TITLE
chore: bump core base to 22.04

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: srsran
-base: core20
+base: core22
 version: '23.11'
 summary: srsRAN is a 4G software radio suite developed by SRS.
 description: |


### PR DESCRIPTION
# Description

Bump the core base from Ubuntu 20.04 to Ubuntu 22.04.
